### PR TITLE
Add a `--scope` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,11 +11,6 @@ const packageJson = JSON.parse(
 
 const argv = yargs(hideBin(process.argv))
   .version(packageJson.version)
-  .command(
-    'client-assertion',
-    'Create a signed JWT to use as the client assertion for the OAuth token post',
-  )
-  .demandCommand(1)
   .option('client-id', {
     demandOption: true,
     describe: 'client id to use for the OAuth token flow',
@@ -26,15 +21,20 @@ const argv = yargs(hideBin(process.argv))
     describe: 'Path to the PEM encoded private key used to sign the assertion',
     type: 'string',
   })
-  .option('scope', {
-    describe: 'scopes to include in the token request and returned access token',
-    default: 'openid',
-    type: 'string',
-  })
+  .command(
+    'client-assertion',
+    'Create a signed JWT to use as the client assertion for the OAuth token post',
+    (yargs) => yargs.option('scope', {
+      describe: 'scopes submitted with the token request',
+      default: 'openid',
+      type: 'string',
+    }),
+  )
   .command(
     'sign-jwt',
     'Only create a signed JWT for use with the Banno back office OAuth flow',
   )
+  .demandCommand(1)
   .strict()
   .help().argv;
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,11 @@ const argv = yargs(hideBin(process.argv))
     describe: 'Path to the PEM encoded private key used to sign the assertion',
     type: 'string',
   })
+  .option('scope', {
+    describe: 'scopes to include in the token request and returned access token',
+    default: 'openid',
+    type: 'string',
+  })
   .command(
     'sign-jwt',
     'Only create a signed JWT for use with the Banno back office OAuth flow',
@@ -35,7 +40,7 @@ const argv = yargs(hideBin(process.argv))
 
 switch (argv._[0].toString().toLowerCase()) {
   case 'client-assertion':
-    clientAssertion(argv['client-id'], argv['private-key']).catch((e) =>
+    clientAssertion(argv['client-id'], argv['private-key'], argv['scope']).catch((e) =>
       console.error(e),
     );
     break;

--- a/lib/commands/client-assertion.js
+++ b/lib/commands/client-assertion.js
@@ -3,16 +3,18 @@ import querystring from 'querystring';
 import fetch from 'node-fetch';
 import {enterpriseOidcTokenUri, signJWT} from './sign-jwt.js';
 
-export const clientAssertion = async (clientId, privateKeyPath) => {
+export const clientAssertion = async (clientId, privateKeyPath, scopes) => {
   // Obtain an access token to call banno apis
   const jwt = await signJWT(clientId, privateKeyPath);
-
+  if (Array.isArray(scopes)) {
+    scopes = scopes.join(' ');
+  }
   const tokenPayload = {
     client_assertion: jwt,
     client_assertion_type:
       'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
     grant_type: 'client_credentials',
-    scope: 'openid',
+    scope: scopes,
   };
   process.stdout.write(
     `To obtain an access token, make a POST to the ${chalk.yellow('https://login.jackhenry.com/a/oidc-provider/api/v0/token')} endpoint.


### PR DESCRIPTION
Add an option to control which scopes are requested as part of the client assertion token request. Defaults to `openid`.